### PR TITLE
Snopt driver options

### DIFF
--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -50,7 +50,7 @@ class pyOptSparseDriver(Driver):
         self.opt_settings = {}
 
         self.pyopt_excludes = ['optimizer', 'title', 'print_results',
-                               'pyopt_diff', 'exit_flag', 'SNOPT']
+                               'pyopt_diff', 'exit_flag' ]
 
         self.pyOpt_solution = None
 


### PR DESCRIPTION
Added opt_settings to pyoptsparse_driver that is a standard dict for settings specific to the different optimizers with pyoptsparse.
