### PR TITLE
Support for parallel DoE execution

### DIFF
--- a/examples/doe_example.py
+++ b/examples/doe_example.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+""" Running DOE experiments (in parallel)"""
+
+from __future__ import print_function
+
+import numpy as np
+
+from openmdao.api import IndepVarComp
+from openmdao.api import Component, Group, ParallelDOEGroup
+from openmdao.api import Problem
+from openmdao.api import UniformDriver
+from openmdao.api import DumpRecorder
+from openmdao.api import NLGaussSeidel
+
+from openmdao.core.mpi_wrap import MPI
+
+class DUT(Component):
+    def __init__(self):
+        super(DUT, self).__init__()
+        self.add_param('x', val=0.)
+        self.add_output('y', shape=1)
+
+    def solve_nonlinear(self, params, unknowns, resids):
+        """ Doesn't do much.  Just multiply by 3"""
+        sum([j*j for j in xrange(10000000)])    # dummy delay (busy loop)
+        unknowns['y'] = 3.0*params['x']
+        
+if __name__ == "__main__":
+
+    if MPI: # pragma: no cover
+        # if you called this script with 'mpirun', then use the petsc data passing
+        from openmdao.core.petsc_impl import PetscImpl as impl
+    else:
+        # if you didn't use `mpirun`, then use the numpy data passing
+        from openmdao.api import BasicImpl as impl
+
+    problem = Problem(impl=impl)
+    root = problem.root = ParallelDOEGroup(impl.world_comm().size)
+    root.add('indep_var', IndepVarComp('x', val=7.0))
+    root.add('dut', DUT())
+
+    root.connect('indep_var.x', 'dut.x')    
+
+    problem.driver = UniformDriver(num_samples = 10)
+    problem.driver.add_desvar('indep_var.x', low=4410.0,  high=4450.0)
+    problem.driver.add_objective('dut.y')
+
+    recorder = DumpRecorder('dump')
+    problem.driver.add_recorder(recorder)
+
+    problem.setup()
+    problem.run()
+
+    problem['dut.y']
+
+    for recorder in problem.driver.recorders:
+        recorder.close()

--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -13,6 +13,7 @@ from openmdao.core.component import Component
 from openmdao.core.group import Group
 from openmdao.core.parallel_group import ParallelGroup
 from openmdao.core.parallel_fd_group import ParallelFDGroup
+from openmdao.core.parallel_doe_group import ParallelDOEGroup
 from openmdao.core.problem import Problem
 from openmdao.core.system import System
 from openmdao.core.driver import Driver

--- a/openmdao/core/mpi_wrap.py
+++ b/openmdao/core/mpi_wrap.py
@@ -51,6 +51,7 @@ def under_mpirun():
     # implementations.
     for name in os.environ.keys():
         if name == 'OMPI_COMM_WORLD_RANK' or \
+           name == 'MPIEXEC_HOSTNAME' or \
            name.startswith('MPIR_') or \
            name.startswith('MPICH_'):
             return True

--- a/openmdao/core/parallel_doe_group.py
+++ b/openmdao/core/parallel_doe_group.py
@@ -1,0 +1,96 @@
+""" Defines the base class for a ParallelDOEGroup in OpenMDAO.
+It is used as the top-level system for running parallel DOE sweeps"""
+
+from __future__ import print_function
+
+import os
+from six import itervalues
+
+from openmdao.core.group import Group
+from openmdao.util.array_util import evenly_distrib_idxs
+from openmdao.core.mpi_wrap import MPI
+
+trace = os.environ.get('OPENMDAO_TRACE')
+if trace: # pragma: no cover
+    from openmdao.core.mpi_wrap import debug
+else:
+    def debug(*arg):
+        pass
+
+class ParallelDOEGroup(Group):
+    """A Group that can run DOE in parallel.
+
+    Args
+    ----
+    num_par_doe : int(1)
+        Number of DOE's to perform in parallel.  If num_par_doe is 1,
+        this just behaves like a normal Group.
+
+    """
+    def __init__(self, num_par_doe):
+        super(ParallelDOEGroup, self).__init__()
+
+        self._num_par_doe = num_par_doe
+        self._par_doe_id = 0
+
+    def _setup_communicators(self, comm):
+        """
+        Assign communicator to this `Group` and all of its subsystems.
+
+        Args
+        ----
+        comm : an MPI communicator (real or fake)
+            The communicator being offered by the parent system.
+        """
+        if self._num_par_doe < 1:
+            raise ValueError("'%s': _num_par_doe must be >= 1 but value is %s." %
+                              (self.pathname, self._num_par_doe))
+        if not MPI:
+            self._num_par_doe = 1
+
+        self._full_comm = comm
+
+        # figure out which parallel DOE we are associated with
+        if self._num_par_doe > 1:
+            minprocs, maxprocs = super(ParallelDOEGroup, self).get_req_procs()
+            sizes, offsets = evenly_distrib_idxs(self._num_par_doe, comm.size)
+
+            # a 'color' is assigned to each subsystem, with
+            # an entry for each processor it will be given
+            # e.g. [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3]
+            color = []
+            for i in range(self._num_par_doe):
+                color.extend([i]*sizes[i])
+
+            self._par_doe_id = color[comm.rank]
+
+            # create a sub-communicator for each color and
+            # get the one assigned to our color/process
+            debug('%s: splitting comm, doe_id=%s' % (self.pathname,
+                                                    self._par_doe_id))
+            comm = comm.Split(self._par_doe_id)
+
+        self._local_subsystems = []
+
+        self.comm = comm
+
+        for sub in itervalues(self._subsystems):
+            sub._setup_communicators(comm)
+            if self.is_active() and sub.is_active():
+                self._local_subsystems.append(sub)
+
+    def get_req_procs(self):
+        """
+        Returns
+        -------
+        tuple
+            A tuple of the form (min_procs, max_procs), indicating the
+            min and max processors usable by this `Group`.
+        """
+        minprocs, maxprocs = super(ParallelDOEGroup, self).get_req_procs()
+
+        minprocs *= self._num_par_doe
+        if maxprocs is not None:
+            maxprocs *= self._num_par_doe
+
+        return (minprocs, maxprocs)

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -17,6 +17,7 @@ from openmdao.core.group import Group
 from openmdao.core.component import Component
 from openmdao.core.parallel_group import ParallelGroup
 from openmdao.core.parallel_fd_group import ParallelFDGroup
+from openmdao.core.parallel_doe_group import ParallelDOEGroup
 from openmdao.core.basic_impl import BasicImpl
 from openmdao.core.checks import check_connections
 from openmdao.core.driver import Driver
@@ -643,7 +644,9 @@ class Problem(System):
             # Indicate that there are no parallel systems if user is running under MPI
             if self.comm.rank == 0:
                 for grp in self.root.subgroups(recurse=True, include_self=True):
-                    if isinstance(grp, ParallelGroup) or isinstance(grp, ParallelFDGroup):
+                    if (isinstance(grp, ParallelGroup) or
+                        isinstance(grp, ParallelFDGroup) or 
+                        isinstance(grp, ParallelDOEGroup)):
                         break
                 else:
                     parr = False

--- a/openmdao/devtools/debug.py
+++ b/openmdao/devtools/debug.py
@@ -5,7 +5,7 @@ import sys
 from pprint import pformat
 from functools import wraps
 from resource import getrusage, RUSAGE_SELF, RUSAGE_CHILDREN
-
+from six import itervalues
 
 def dump_meta(system, nest=0, out_stream=sys.stdout):
     """
@@ -57,7 +57,7 @@ def dump_meta(system, nest=0, out_stream=sys.stdout):
 
     nest += 3
     for sub in itervalues(system._subsystems):
-        sub.dump_meta(nest, out_stream=out_stream)
+        dump_meta(sub, nest, out_stream=out_stream)
 
     out_stream.flush()
 

--- a/openmdao/drivers/predeterminedruns_driver.py
+++ b/openmdao/drivers/predeterminedruns_driver.py
@@ -4,8 +4,19 @@ Baseclass for design-of-experiments Drivers that have pre-determined parameter s
 
 from openmdao.core.driver import Driver
 from openmdao.util.record_util import create_local_meta, update_local_meta
+from openmdao.core.parallel_doe_group import ParallelDOEGroup
+from openmdao.util.array_util import evenly_distrib_idxs
 from six import iteritems
+import os
 
+from openmdao.core.mpi_wrap import MPI
+
+trace = os.environ.get('OPENMDAO_TRACE')
+if trace: # pragma: no cover
+    from openmdao.core.mpi_wrap import debug
+else:
+    def debug(*arg):
+        pass
 
 class PredeterminedRunsDriver(Driver):
     """ Baseclass for design-of-experiments Drivers that have pre-determined parameter sets.
@@ -16,14 +27,28 @@ class PredeterminedRunsDriver(Driver):
             raise Exception('PredeterminedRunsDriver is an abstract class')
         super(PredeterminedRunsDriver, self).__init__()
 
+    def _setup(self, root):
+        super(PredeterminedRunsDriver, self)._setup(root)
+        if MPI and isinstance(root, ParallelDOEGroup): # pragma: no cover
+            comm = root._full_comm
+            job_list = None
+            if comm.rank == 0:
+                debug('Parallel DOE using %d threads' % (root._num_par_doe,))
+                run_list = list(self._build_runlist()) # need to run the iterator
+                run_sizes, run_offsets = evenly_distrib_idxs(root._num_par_doe, len(run_list))
+                job_list = [run_list[o:o+s] for o, s in zip(run_offsets, run_sizes)]
+            self.run_list = comm.scatter(job_list, root=0)
+            debug('Number of DOE jobs: %s' % (len(self.run_list),))
+        else:
+            self.run_list = self._build_runlist()
+
+
     def run(self, problem):
         """Build a runlist and execute the Problem for each set of generated parameters.        
         """
 
-        run_list = self._build_runlist()
-
         # For each runlist entry, run the system and record the results
-        for run in run_list:
+        for run in self.run_list:
             for dv_name, dv_val in iteritems(run):
                 self.set_desvar(dv_name, dv_val)
 


### PR DESCRIPTION
We don't expect this PR to be merged right now, but hope to use it as a place to discuss an addition we're working on. @volgy worked on this, and describes the problem and approach:

With the help of the OpenMDOA team (thanks!) we managed to implement parallel DOE executions. This functionality uses a new class in core (ParallelDOEGroup) and our DOE base class.

There is a simple example in the repo how to run these experiments:
**OpenMDAO/blob/parallel_doe/examples/doe_example.py**

Either you run it as is or under mpi: `mpirun -n 4 doe_example.py`

At line 41 we instantiate a constant component. If you change this line and set `pass_by_obj=True`, the program will not run under MPI anymore (for obvious reasons in the data transfer layer).

We rely on this feature (`pass_by_obj`) for dynamic typing, so I wonder if there is any good (not too hacky) ideas on how to overcome this issue.
