### PR TITLE
Use pkg_resources to enable running from .zip file

### DIFF
--- a/openmdao/units/units.py
+++ b/openmdao/units/units.py
@@ -880,5 +880,6 @@ def get_conversion_tuple(src_units, target_units):
 
 
 # Load in the default unit library
-with open(os.path.join(os.path.dirname(__file__), 'unit_library.ini')) as default_lib:
+import pkg_resources
+with pkg_resources.resource_stream(__name__, "unit_library.ini") as default_lib:
     import_library(default_lib)

--- a/openmdao/util/profile.py
+++ b/openmdao/util/profile.py
@@ -537,9 +537,9 @@ def prof_view():
     call_graph, totals = process_profile(options.rawfiles)
 
     viewer = "icicle.html"
-    code_dir = os.path.dirname(os.path.abspath(__file__))
 
-    with open(os.path.join(code_dir, viewer), "r") as f:
+    import pkg_resources
+    with pkg_resources.resource_stream(__name__, viewer) as default_lib:
         template = f.read()
 
     graphjson = json.dumps(call_graph)

--- a/openmdao/util/viewconns.py
+++ b/openmdao/util/viewconns.py
@@ -133,9 +133,8 @@ def view_connections(root, outfile='connections.html', show_browser=True,
 
     viewer = 'connect_table.html'
 
-    code_dir = os.path.dirname(os.path.abspath(__file__))
-
-    with open(os.path.join(code_dir, viewer), "r") as f:
+    import pkg_resources
+    with pkg_resources.resource_stream(__name__, viewer) as default_lib:
         template = f.read()
 
     graphjson = json.dumps(data)


### PR DESCRIPTION
This change allows you to put OpenMDAO into a .zip file for deployment.